### PR TITLE
Stop dropping sprites on the right/bottom edges when zoom < 1.0

### DIFF
--- a/pyscroll/group.py
+++ b/pyscroll/group.py
@@ -59,6 +59,7 @@ class PyscrollGroup(pygame.sprite.LayeredUpdates):
         """
         ox, oy = self._map_layer.get_center_offset()
         draw_area = surface.get_rect()
+        view_rect = self.view
 
         new_surfaces = list()
         spritedict = self.spritedict
@@ -67,7 +68,7 @@ class PyscrollGroup(pygame.sprite.LayeredUpdates):
 
         for spr in self.sprites():
             new_rect = spr.rect.move(ox, oy)
-            if new_rect.colliderect(draw_area):
+            if spr.rect.colliderect(view_rect):
                 try:
                     new_surfaces_append((spr.image, new_rect, gl(spr), spr.blendmode))
                 except AttributeError:


### PR DESCRIPTION
Instead of checking for collisions between the shifted sprite rect and the surface check the sprite's actual rect against the view rect.

With zoom set to less than 1.0 whenever (0,0) of the map is moved towards the right or bottom edges of the draw area sprites would drop out early.
