### PR TITLE
Fix for frame of stale animations after calling reload_animations

### DIFF
--- a/pyscroll/data.py
+++ b/pyscroll/data.py
@@ -156,6 +156,7 @@ class PyscrollDataAdapter:
         """
         self._update_time()
         self._animation_queue = list()
+        self._animated_tile = dict()
         self._tracked_gids = set()
         self._animation_map = dict()
 


### PR DESCRIPTION
Fix issue where PyscrollDataAdapter.reload_animations didn't clear self._animated_tile leading to a frame of stale animations after reload_animations is called.