### PR TITLE
Allow sorting behavior of sprites and overlaying tiles to be tuned

### DIFF
--- a/pyscroll/data.py
+++ b/pyscroll/data.py
@@ -156,6 +156,7 @@ class PyscrollDataAdapter:
         """
         self._update_time()
         self._animation_queue = list()
+        self._animated_tile = dict()
         self._tracked_gids = set()
         self._animation_map = dict()
 


### PR DESCRIPTION
Add set_blit_list_sort_key method to BufferedRenderer allowing the sorting behavior of sprites and overlaying tiles to be tuned.  For my purpose, instead of drawing sprites over tiles in the same layer I want to favor the surface with higher bottom coordinate and then favor sprite over tile.  The default behavior is retained but can now be tuned to for different appilcations by setting an alternate key function for the sort.  This ability to tailer the drawing order may address https://github.com/bitcraft/pyscroll/issues/47.